### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ my $m = META6.new(   name        => 'META6',
 
 print $m.to-json;
 
-my $m = META6.new('./META6.json');
+my $m = META6.new(file => './META6.json');
 $m<version description> = v0.0.2, 'Work with Perl 6 META files even better';
 spurt('./META6.json', $m.to-json);
 ```

--- a/lib/META6.pm
+++ b/lib/META6.pm
@@ -39,7 +39,7 @@ my $m = META6.new(   name        => 'META6',
 
 print $m.to-json;
 
-my $m = META6.new('./META6.json');
+my $m = META6.new(file => './META6.json');
 $m<version description> = v0.0.2, 'Work with Perl 6 META files even better';
 spurt('./META6.json', $m.to-json);
 


### PR DESCRIPTION
The example shows calling new with a single positional parameter. This produces and error:
```
Default constructor for 'META6' only takes named arguments
```

The filename is now supplied as the 'file' named argument.